### PR TITLE
fix(ci): Correct build directory in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       NODE_VERSION: '20'
       INSTALL_CMD: 'npm ci'
       BUILD_CMD: 'npm run build'
-      BUILD_DIR: 'dist/spa'        # <— your build outputs here (Quasar SPA typical)
+      BUILD_DIR: 'dist'        # <— your build outputs here (Quasar SPA typical)
       SITE_URL: 'https://jobequal.ch'
       HEALTHCHECK_PATH: '/'
       HEALTHCHECK_RETRIES: '10'


### PR DESCRIPTION
The GitHub Actions workflow for deployment was failing because it was configured to look for the build output in `dist/spa`.

After analyzing the project's Vite configuration, it was determined that the correct build output directory is `dist`.

This change updates the `BUILD_DIR` environment variable in the `.github/workflows/deploy.yml` file to point to the correct `dist` directory, enabling the deployment pipeline to locate the build artifacts and proceed with the deployment steps.