### PR TITLE
Fix(ci): use WIF provider variable in Cloud Run workflow

### DIFF
--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: google-github-actions/auth@v2
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
-          workload_identity_provider: projects/${{ vars.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github/providers/gha
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: deploy@${{ vars.GCP_PROJECT_ID }}.iam.gserviceaccount.com
 
       - uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
Updates the `cloud-run.yml` workflow to use a GitHub variable (`GCP_WIF_PROVIDER`) for the Workload Identity Federation provider name. This makes the workflow more flexible and aligns with the user's provided setup guide.